### PR TITLE
fix clang issues

### DIFF
--- a/include/jsonrpcpp.hpp
+++ b/include/jsonrpcpp.hpp
@@ -70,6 +70,8 @@ public:
 
 	Entity(entity_t type);
 	virtual ~Entity() = default;
+	Entity(const Entity &) = default;
+	Entity & operator=(const Entity &) = default;
 
 	bool is_exception();
 	bool is_id();
@@ -100,7 +102,6 @@ class NullableEntity : public Entity
 public:
 	NullableEntity(entity_t type);
 	NullableEntity(entity_t type, std::nullptr_t);
-	~NullableEntity() override = default;
 #ifdef _MSC_VER
 	virtual operator bool() const
 #else
@@ -312,7 +313,6 @@ public:
 	RpcException(const char* text);
 	RpcException(const std::string& text);
 
-	~RpcException() override = default;
 	const char* what() const noexcept override;
 
 protected:


### PR DESCRIPTION
fix issues similar to 
 /jsonrpcpp/include/jsonrpcpp.hpp:103:2: error: definition of implicit copy constructor for 'NullableEntity' is deprecated because it has a user-declared destructor [-Werror,-Wdeprecated]
