### PR TITLE
Fixed crash on receiving request with "params": null

### DIFF
--- a/include/jsonrpcpp.hpp
+++ b/include/jsonrpcpp.hpp
@@ -695,7 +695,13 @@ inline Parameter::Parameter(const std::string& key1, const Json& value1, const s
 
 inline void Parameter::parse_json(const Json& json)
 {
-    if (json.is_array())
+    if (json.is_null())
+    {
+        param_array.clear();
+        param_map.clear();
+        type = value_t::null;
+    }
+    else if (json.is_array())
     {
         param_array = json.get<std::vector<Json>>();
         param_map.clear();

--- a/include/jsonrpcpp.hpp
+++ b/include/jsonrpcpp.hpp
@@ -700,6 +700,7 @@ inline void Parameter::parse_json(const Json& json)
         param_array.clear();
         param_map.clear();
         type = value_t::null;
+        isNull = true;
     }
     else if (json.is_array())
     {
@@ -737,7 +738,7 @@ inline bool Parameter::is_map() const
 
 inline bool Parameter::is_null() const
 {
-    return isNull;
+    return type == value_t::null;
 }
 
 inline bool Parameter::has(const std::string& key) const

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -27,3 +27,20 @@ TEST_CASE("Main test")
     REQUIRE(response.result() == 19);
     REQUIRE(response.to_json() == nlohmann::json::parse(R"({"jsonrpc": "2.0", "result": 19, "id": 3})"));
 }
+
+TEST_CASE("Null parameter")
+{
+    jsonrpcpp::entity_ptr entity =
+        jsonrpcpp::Parser::do_parse(R"({"jsonrpc": "2.0", "method": "nullrequest", "params": null, "id": 4})");
+    REQUIRE(entity->is_request());
+    jsonrpcpp::request_ptr request = dynamic_pointer_cast<jsonrpcpp::Request>(entity);
+    REQUIRE(request->method() == "nullrequest");
+    REQUIRE(request->params().to_json() == nullptr);
+    REQUIRE(request->params().is_null() == true);
+    int result = 12;
+    jsonrpcpp::Response response(*request, result);
+    REQUIRE(response.id().type() == jsonrpcpp::Id::value_t::integer);
+    REQUIRE(response.id().int_id() == 4);
+    REQUIRE(response.result() == 12);
+    REQUIRE(response.to_json() == nlohmann::json::parse(R"({"jsonrpc": "2.0", "result": 12, "id": 4})"));
+}


### PR DESCRIPTION
When parsing correctly formed requests/notifications with
~~~~~~~~~~~~~~~~~~~
"params": null
~~~~~~~~~~~~~~~~~~~
a crash occurs. Checking if its null beforehand prevents this.